### PR TITLE
Fix bugs in gbt and cuml-svm

### DIFF
--- a/cuml_bench/svm.py
+++ b/cuml_bench/svm.py
@@ -15,7 +15,7 @@
 # ===============================================================================
 
 import argparse
-
+import numpy as np
 import bench
 from cuml.svm import SVC
 
@@ -52,6 +52,8 @@ params.n_classes = y_train[y_train.columns[0]].nunique()
 clf = SVC(C=params.C, kernel=params.kernel, cache_size=params.cache_size_mb,
           tol=params.tol, gamma=params.gamma, probability=params.probability,
           degree=params.degree)
+X_train = X_train.to_cupy()
+y_train = y_train.to_cupy()
 
 fit_time, _ = bench.measure_function_time(clf.fit, X_train, y_train, params=params)
 
@@ -73,6 +75,8 @@ else:
 
 predict_train_time, y_pred = bench.measure_function_time(
     clf_predict, X_train, params=params)
+
+y_train = y_train.get()
 train_acc = metric_call(y_train, y_pred)
 
 predict_test_time, y_pred = bench.measure_function_time(

--- a/xgboost_bench/gbt.py
+++ b/xgboost_bench/gbt.py
@@ -25,11 +25,11 @@ def convert_probs_to_classes(y_prob):
     return np.array([np.argmax(y_prob[i]) for i in range(y_prob.shape[0])])
 
 
-def convert_xgb_predictions(y_pred, objective):
+def convert_xgb_predictions(y_pred, objective, threshold=0.5):
     if objective == 'multi:softprob':
         y_pred = convert_probs_to_classes(y_pred)
     elif objective == 'binary:logistic':
-        y_pred = y_pred.astype(np.int32)
+        y_pred = (y_pred > threshold).astype(np.int32)
     return y_pred
 
 


### PR DESCRIPTION
* fix probability to prediction conversion error in gbt

 * Fix svm Does not work for some dataset
    
    Problem: the format is not compatible to cudf
    solution: explicitly convert the data to cupy and convert back to numpy when benchmark is done for accuracy calculations.
    comment: the conversion is out of benchmark measure_function_time.